### PR TITLE
tnr_ using same cutoff as confusionMatrix_

### DIFF
--- a/src/confusionMatrix_.cpp
+++ b/src/confusionMatrix_.cpp
@@ -54,10 +54,9 @@ double npv_(NumericVector actual, NumericVector predicted, double cutoff) {
 // [[Rcpp::export]]
 double tnr_(NumericVector actual, NumericVector predicted, double cutoff) {
 
-  double TN = sum((predicted < cutoff) & (actual == 0));
-  double N = sum(actual == 0);
-  double tnr = TN/N;
+  NumericMatrix cMat = confusionMatrix_(actual, predicted, cutoff);
 
+  double tnr = cMat(0,0) / (cMat(0,0) + cMat(1,0));
   return tnr;
 
 }


### PR DESCRIPTION
Hi Tyler,

Hope you are doing well. Thanks for this great package.

On https://github.com/JackStat/ModelMetrics/blob/master/src/confusionMatrix_.cpp:
- `confusionMatrix_` considers predictions as negative if the value is **<=** 0
- `tnr_` considers predictions as negative if the value is **<** 0.

I suggest to standardise it using `confusionMatrix_`, as in the attached patch.

I am not fully aware, but I strongly suggest checking the functions `mcc_` and `kappa_` as they might have a different result due to the different way it is calculated.

Best wishes,
Victor