### PR TITLE
Add named matrix option for confusionMatrix()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,5 +13,5 @@ LinkingTo: Rcpp
 Imports:
     Rcpp,
     data.table
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1
 Suggests: testthat

--- a/R/ModelMetrics.R
+++ b/R/ModelMetrics.R
@@ -88,11 +88,21 @@ mauc <- function(actual, predicted){
 #' @param actual A vector of the labels
 #' @param predicted A vector of predicted values
 #' @param cutoff A cutoff for the predicted values
+#' @param use_names If \code{TRUE}, the dimnames of the output matrix will be labelled to indicate
+#'   which axes show the actual and predicted classes.
+#'
+#' @examples
+#' actual <- c(0, 0, 1)
+#' predicted <- c(1, 0, 1)
+#'
+#' confusionMatrix(actual, predicted)
+#'
+#' confusionMatrix(actual, predicted, use_names = TRUE)
 #'
 #' @export
 
-confusionMatrix <- function(actual, predicted, cutoff = .5){
-  confusionMatrix_(actual, predicted, cutoff)
+confusionMatrix <- function(actual, predicted, cutoff = .5, use_names = FALSE){
+  confusionMatrix_(actual, predicted, cutoff, use_names)
 }
 
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,8 +17,8 @@ auc3_ <- function(actual, predicted, ranks) {
     .Call('_ModelMetrics_auc3_', PACKAGE = 'ModelMetrics', actual, predicted, ranks)
 }
 
-confusionMatrix_ <- function(actual, predicted, cutoff) {
-    .Call('_ModelMetrics_confusionMatrix_', PACKAGE = 'ModelMetrics', actual, predicted, cutoff)
+confusionMatrix_ <- function(actual, predicted, cutoff, use_names = FALSE) {
+    .Call('_ModelMetrics_confusionMatrix_', PACKAGE = 'ModelMetrics', actual, predicted, cutoff, use_names)
 }
 
 ppv_ <- function(actual, predicted, cutoff) {

--- a/man/confusionMatrix.Rd
+++ b/man/confusionMatrix.Rd
@@ -4,7 +4,7 @@
 \alias{confusionMatrix}
 \title{Confusion Matrix}
 \usage{
-confusionMatrix(actual, predicted, cutoff = 0.5)
+confusionMatrix(actual, predicted, cutoff = 0.5, use_names = FALSE)
 }
 \arguments{
 \item{actual}{A vector of the labels}
@@ -12,7 +12,19 @@ confusionMatrix(actual, predicted, cutoff = 0.5)
 \item{predicted}{A vector of predicted values}
 
 \item{cutoff}{A cutoff for the predicted values}
+
+\item{use_names}{If \code{TRUE}, the dimnames of the output matrix will be labelled to indicate
+which axes show the actual and predicted classes.}
 }
 \description{
 Create a confusion matrix given a specific cutoff.
+}
+\examples{
+actual <- c(0, 0, 1)
+predicted <- c(1, 0, 1)
+
+confusionMatrix(actual, predicted)
+
+confusionMatrix(actual, predicted, use_names = TRUE)
+
 }

--- a/man/logLoss.Rd
+++ b/man/logLoss.Rd
@@ -12,8 +12,7 @@
 \usage{
 logLoss(...)
 
-\method{logLoss}{default}(actual, predicted, distribution = "binomial",
-  ...)
+\method{logLoss}{default}(actual, predicted, distribution = "binomial", ...)
 
 \method{logLoss}{glm}(modelObject, ...)
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -54,15 +54,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // confusionMatrix_
-NumericMatrix confusionMatrix_(NumericVector actual, NumericVector predicted, double cutoff);
-RcppExport SEXP _ModelMetrics_confusionMatrix_(SEXP actualSEXP, SEXP predictedSEXP, SEXP cutoffSEXP) {
+NumericMatrix confusionMatrix_(NumericVector actual, NumericVector predicted, double cutoff, bool use_names);
+RcppExport SEXP _ModelMetrics_confusionMatrix_(SEXP actualSEXP, SEXP predictedSEXP, SEXP cutoffSEXP, SEXP use_namesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericVector >::type actual(actualSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type predicted(predictedSEXP);
     Rcpp::traits::input_parameter< double >::type cutoff(cutoffSEXP);
-    rcpp_result_gen = Rcpp::wrap(confusionMatrix_(actual, predicted, cutoff));
+    Rcpp::traits::input_parameter< bool >::type use_names(use_namesSEXP);
+    rcpp_result_gen = Rcpp::wrap(confusionMatrix_(actual, predicted, cutoff, use_names));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -308,7 +309,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_ModelMetrics_auc_", (DL_FUNC) &_ModelMetrics_auc_, 2},
     {"_ModelMetrics_auc2_", (DL_FUNC) &_ModelMetrics_auc2_, 2},
     {"_ModelMetrics_auc3_", (DL_FUNC) &_ModelMetrics_auc3_, 3},
-    {"_ModelMetrics_confusionMatrix_", (DL_FUNC) &_ModelMetrics_confusionMatrix_, 3},
+    {"_ModelMetrics_confusionMatrix_", (DL_FUNC) &_ModelMetrics_confusionMatrix_, 4},
     {"_ModelMetrics_ppv_", (DL_FUNC) &_ModelMetrics_ppv_, 3},
     {"_ModelMetrics_npv_", (DL_FUNC) &_ModelMetrics_npv_, 3},
     {"_ModelMetrics_tnr_", (DL_FUNC) &_ModelMetrics_tnr_, 3},

--- a/src/confusionMatrix_.cpp
+++ b/src/confusionMatrix_.cpp
@@ -2,7 +2,7 @@
 using namespace Rcpp;
 
 // [[Rcpp::export]]
-NumericMatrix confusionMatrix_(NumericVector actual, NumericVector predicted, double cutoff) {
+NumericMatrix confusionMatrix_(NumericVector actual, NumericVector predicted, double cutoff, bool use_names = false) {
 
   NumericMatrix cMat = NumericMatrix(Dimension(2, 2));
 
@@ -14,6 +14,11 @@ NumericMatrix confusionMatrix_(NumericVector actual, NumericVector predicted, do
   cMat(1,0) = sum((predicted > cutoff) & (actual == 0));
   // True positives
   cMat(1,1) = sum((predicted > cutoff) & (actual == 1));
+
+  if (use_names) {
+    colnames(cMat) = CharacterVector::create("actual_0", "actual_1");
+    rownames(cMat) = CharacterVector::create("predicted_0", "predicted_1");
+  }
 
   return cMat;
 

--- a/tests/testthat/test_confusionMatrix.R
+++ b/tests/testthat/test_confusionMatrix.R
@@ -1,0 +1,13 @@
+test_that("`confusionMatrix()` respects the `use_names` option", {
+  act <- c(0, 0, 1)
+  pred <- c(1, 0, 1)
+
+  # Expect no names by default
+  cm <- confusionMatrix(act, pred)
+  expect_null(rownames(cm))
+  expect_null(colnames(cm))
+
+  cm2 <- confusionMatrix(act, pred, use_names = TRUE)
+  expect_equal(rownames(cm2), c("predicted_0", "predicted_1"))
+  expect_equal(colnames(cm2), c("actual_0", "actual_1"))
+})


### PR DESCRIPTION
Fixes #34 

* Add an option to name the output of `confusionMatrix()`
* Add tests to ensure the option is respected
* Update documentation
* Test and `devtools::check()` pass